### PR TITLE
Callregs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: epanet2toolkit
 Type: Package
 Title: Call 'EPANET' Functions to Simulate Pipe Networks
-Version: 0.4.1
+Version: 0.4.2
 Date: 2019-12-30
 Authors@R: c(
    person("Ernesto", "Arandia", email="earandia.ie@gmail.com", role='aut'),

--- a/src/init.c
+++ b/src/init.c
@@ -75,9 +75,6 @@ static const R_CallMethodDef callMethods[] ={
 	{"enNextH"        , (DL_FUNC) &enNextH        , 0},
 	{"enCloseH"       , (DL_FUNC) &enCloseH       , 0},
 	{"enSetPatternValue",(DL_FUNC) &enSetPatternValue , 3},
-	{"int2SEXP"       , (DL_FUNC) &int2SEXP       , 1},
-	{"char2SEXP"      , (DL_FUNC) &char2SEXP      , 1},
-	{"float2SEXP"     , (DL_FUNC) &float2SEXP     , 1},
 	{"enSetQualType"  , (DL_FUNC) &enSetQualType  , 4},
     NULL
 };


### PR DESCRIPTION
some functions were declared as accessible to `.Call` but in fact are not intended for that usage.  this pr removes them 